### PR TITLE
Unexport status

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -106,7 +106,6 @@ module DataStructures
         isfull
     include("circular_buffer.jl")
 
-    export status
     export deref_key, deref_value, deref, advance, regress
 
     export PriorityQueue


### PR DESCRIPTION
`status()` is too generic of an export and not something you'd expect package `DataStructures` to export. More specific name (`token_status`? `semitoken_status`?) could be better, or just fully-qualified `DataStructures.status`